### PR TITLE
Upgrade to Java 21 and Jakarta EE 10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [21.0.0-SNAPSHOT] - 2026-03-26
+### Changed
+- Updated project version to `21.0.0-SNAPSHOT`
+- Updated `maven-framework-parent-pom` to `21.0.0-SNAPSHOT` (Java 21, Jakarta EE 10)
+- Updated `maven-common-bom` to `21.0.0-SNAPSHOT` (CDI 4.0.1, Jakarta EE API 10.0.0)
+- Updated CDI `beans.xml` descriptors from version `1.1` to `4.0` (`beans_4_0.xsd`) across all modules
+- Replaced `org.glassfish:javax.json` dependency with `org.glassfish:jakarta.json` in all modules
+- Resolved git merge conflicts in `JsonObjects`, `MetadataJdbcRepository`, `FileServiceTestClient`, `AlfrescoFileSender`, and `AlfrescoFileRemover` — all migrated to `jakarta.*` imports
+- Fixed `javax.ws.rs` imports in `AlfrescoRestClientTest` to use `jakarta.ws.rs`
+- Updated `openejb.version` in `maven-common-bom` from `8.0.14` to `10.0.0` (TomEE 10 / Jakarta EE 10 / CDI 4.0 support via OpenWebBeans 4.0.3)
+- Updated JaCoCo to `0.8.12` in `maven-parent-pom` for Java 21 class file support
+- Added `argLine` to maven-failsafe-plugin in integration-tests profile with `-Dnet.bytebuddy.experimental=true --add-opens java.base/java.lang=ALL-UNNAMED` for Mockito compatibility on Java 21
+
 ## [17.104.0-M3] - 2025-10-27
 ### Changed
 - Correctly organise AlfrescoRestClient to utilise client lifecycle. 

--- a/file-service-alfresco/file-alfresco/pom.xml
+++ b/file-service-alfresco/file-alfresco/pom.xml
@@ -5,25 +5,25 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>file-service-alfresco</artifactId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>file-alfresco</artifactId>
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -89,7 +89,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.github.tomakehurst</groupId>
+            <groupId>org.wiremock</groupId>
             <artifactId>wiremock</artifactId>
             <scope>test</scope>
         </dependency>

--- a/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRemover.java
+++ b/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRemover.java
@@ -1,18 +1,18 @@
 package uk.gov.justice.services.file.alfresco;
 
 import static java.lang.String.format;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static uk.gov.justice.services.file.alfresco.Headers.headersWithUserId;
 
 import uk.gov.justice.fileservice.common.configuration.GlobalValue;
 import uk.gov.justice.services.file.api.FileOperationException;
 import uk.gov.justice.services.file.api.remover.FileRemover;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
 
 @ApplicationScoped
 public class AlfrescoFileRemover implements FileRemover {

--- a/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRequester.java
+++ b/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRequester.java
@@ -3,7 +3,7 @@ package uk.gov.justice.services.file.alfresco;
 import static java.lang.String.format;
 import static java.util.Optional.empty;
 import static java.util.Optional.ofNullable;
-import static javax.ws.rs.core.MediaType.valueOf;
+import static jakarta.ws.rs.core.MediaType.valueOf;
 import static uk.gov.justice.services.file.alfresco.Headers.headersWithUserId;
 
 import uk.gov.justice.fileservice.common.configuration.GlobalValue;
@@ -13,11 +13,11 @@ import uk.gov.justice.services.file.api.requester.FileRequester;
 import java.io.InputStream;
 import java.util.Optional;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.ProcessingException;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ProcessingException;
 
 @ApplicationScoped
 public class AlfrescoFileRequester implements FileRequester {

--- a/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/AlfrescoFileSender.java
+++ b/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/AlfrescoFileSender.java
@@ -2,10 +2,10 @@ package uk.gov.justice.services.file.alfresco;
 
 import static com.jayway.jsonpath.Configuration.defaultConfiguration;
 import static java.lang.String.format;
-import static javax.ws.rs.client.Entity.entity;
-import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA_TYPE;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
-import static javax.ws.rs.core.Response.Status.OK;
+import static jakarta.ws.rs.client.Entity.entity;
+import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA_TYPE;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static jakarta.ws.rs.core.Response.Status.OK;
 import static org.apache.commons.lang3.StringUtils.isEmpty;
 import static uk.gov.justice.services.file.alfresco.Headers.headersWithUserId;
 
@@ -16,12 +16,12 @@ import uk.gov.justice.services.file.api.sender.FileSender;
 
 import java.io.InputStream;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
 
 import com.jayway.jsonpath.JsonPath;
 import org.jboss.resteasy.plugins.providers.multipart.MultipartFormDataOutput;

--- a/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/AlfrescoRestClient.java
+++ b/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/AlfrescoRestClient.java
@@ -11,15 +11,15 @@ import uk.gov.justice.fileservice.common.configuration.GlobalValue;
 import java.io.InputStream;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation.Builder;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation.Builder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
 
 import org.jboss.resteasy.client.jaxrs.internal.ResteasyClientBuilderImpl;
 

--- a/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/Headers.java
+++ b/file-service-alfresco/file-alfresco/src/main/java/uk/gov/justice/services/file/alfresco/Headers.java
@@ -3,7 +3,7 @@ package uk.gov.justice.services.file.alfresco;
 
 import static java.util.Collections.singletonList;
 
-import javax.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 
 public final class Headers {
 

--- a/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRemoverTest.java
+++ b/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRemoverTest.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.services.file.alfresco;
 
 import static java.util.UUID.randomUUID;
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.mock;
@@ -9,7 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.services.file.alfresco.Headers.headersWithUserId;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRequesterIT.java
+++ b/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRequesterIT.java
@@ -10,7 +10,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.apache.openejb.util.NetworkUtil.getNextAvailablePort;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -25,7 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
-import javax.ws.rs.ProcessingException;
+import jakarta.ws.rs.ProcessingException;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import org.apache.commons.io.IOUtils;

--- a/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRequesterTest.java
+++ b/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileRequesterTest.java
@@ -2,8 +2,8 @@ package uk.gov.justice.services.file.alfresco;
 
 import static java.lang.String.format;
 import static java.util.UUID.randomUUID;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN_TYPE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -17,10 +17,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 
-import javax.ws.rs.InternalServerErrorException;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.ProcessingException;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.InternalServerErrorException;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.ProcessingException;
+import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileSenderIT.java
+++ b/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileSenderIT.java
@@ -9,7 +9,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static java.lang.String.format;
-import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static jakarta.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.apache.openejb.util.NetworkUtil.getNextAvailablePort;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileSenderTest.java
+++ b/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoFileSenderTest.java
@@ -1,8 +1,8 @@
 package uk.gov.justice.services.file.alfresco;
 
 import static java.util.UUID.randomUUID;
-import static javax.ws.rs.core.MediaType.MULTIPART_FORM_DATA_TYPE;
-import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static jakarta.ws.rs.core.MediaType.MULTIPART_FORM_DATA_TYPE;
+import static jakarta.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.apache.commons.io.IOUtils.toInputStream;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.justice.services.file.alfresco.Headers.headersWithUserId;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoRestClientTest.java
+++ b/file-service-alfresco/file-alfresco/src/test/java/uk/gov/justice/services/file/alfresco/AlfrescoRestClientTest.java
@@ -7,17 +7,17 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.Response;
 
 import java.io.InputStream;
 
-import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;

--- a/file-service-alfresco/file-api/pom.xml
+++ b/file-service-alfresco/file-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>file-service-alfresco</artifactId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/file-service-alfresco/pom.xml
+++ b/file-service-alfresco/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.framework</groupId>
         <artifactId>cp-file-service</artifactId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>uk.gov.justice</groupId>

--- a/file-service-bom/pom.xml
+++ b/file-service-bom/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.framework</groupId>
         <artifactId>cp-file-service</artifactId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/file-service-utils/pom.xml
+++ b/file-service-utils/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>uk.gov.justice.framework</groupId>
         <artifactId>cp-file-service</artifactId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.file.service</groupId>
     <artifactId>file-service-utils</artifactId>
-    <version>17.104.0-M4-SNAPSHOT</version>
+    <version>21.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>
@@ -23,8 +23,8 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/cdi/LoggerProducer.java
+++ b/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/cdi/LoggerProducer.java
@@ -1,10 +1,10 @@
 package uk.gov.justice.fileservice.common.cdi;
 
-import javax.annotation.Priority;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Alternative;
-import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.spi.InjectionPoint;
+import jakarta.annotation.Priority;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Alternative;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/configuration/CommonValueAnnotationDef.java
+++ b/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/configuration/CommonValueAnnotationDef.java
@@ -1,6 +1,6 @@
 package uk.gov.justice.fileservice.common.configuration;
 
-import javax.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 
 class CommonValueAnnotationDef {
 

--- a/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/configuration/GlobalValue.java
+++ b/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/configuration/GlobalValue.java
@@ -5,8 +5,8 @@ import static uk.gov.justice.fileservice.common.configuration.CommonValueAnnotat
 
 import java.lang.annotation.Retention;
 
-import javax.enterprise.util.Nonbinding;
-import javax.inject.Qualifier;
+import jakarta.enterprise.util.Nonbinding;
+import jakarta.inject.Qualifier;
 
 @Qualifier
 @Retention(RUNTIME)

--- a/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/configuration/GlobalValueProducer.java
+++ b/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/configuration/GlobalValueProducer.java
@@ -2,9 +2,9 @@ package uk.gov.justice.fileservice.common.configuration;
 
 import static uk.gov.justice.fileservice.common.configuration.CommonValueAnnotationDef.globalValueAnnotationOf;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
-import javax.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 import javax.naming.NamingException;
 
 /**

--- a/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/file/ContentTypeDetector.java
+++ b/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/file/ContentTypeDetector.java
@@ -3,7 +3,7 @@ package uk.gov.justice.fileservice.common.file;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import org.apache.tika.config.TikaConfig;
 import org.apache.tika.detect.Detector;

--- a/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/messaging/JsonObjects.java
+++ b/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/messaging/JsonObjects.java
@@ -2,11 +2,11 @@ package uk.gov.justice.fileservice.common.messaging;
 
 import java.util.function.Function;
 
-import javax.json.Json;
-import javax.json.JsonBuilderFactory;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
-import javax.json.JsonReaderFactory;
+import jakarta.json.Json;
+import jakarta.json.JsonBuilderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonReaderFactory;
 
 /**
  * Collection of static utility methods for getting deep values from a {@link JsonObject}.

--- a/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/util/UtcClock.java
+++ b/file-service-utils/src/main/java/uk/gov/justice/fileservice/common/util/UtcClock.java
@@ -5,7 +5,7 @@ import static java.time.temporal.ChronoUnit.MILLIS;
 
 import java.time.ZonedDateTime;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * Implementation of a clock that always generates a {@link ZonedDateTime} in UTC.

--- a/file-service-utils/src/main/resources/META-INF/beans.xml
+++ b/file-service-utils/src/main/resources/META-INF/beans.xml
@@ -1,10 +1,8 @@
 <!-- Marker file indicating CDI should be enabled -->
 
 <beans xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
-      http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-
-       bean-discovery-mode="all">
+       xmlns="https://jakarta.ee/xml/ns/jakartaee"
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
 
 </beans>

--- a/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/cdi/LoggerProducerTest.java
+++ b/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/cdi/LoggerProducerTest.java
@@ -8,7 +8,7 @@ import static org.mockito.Mockito.when;
 
 import uk.gov.justice.fileservice.common.util.Clock;
 
-import javax.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/configuration/GlobalValueProducerTest.java
+++ b/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/configuration/GlobalValueProducerTest.java
@@ -5,8 +5,8 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-import javax.enterprise.inject.spi.Annotated;
-import javax.enterprise.inject.spi.InjectionPoint;
+import jakarta.enterprise.inject.spi.Annotated;
+import jakarta.enterprise.inject.spi.InjectionPoint;
 import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
 import javax.naming.NamingException;

--- a/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/file/ContentTypeDetectorTest.java
+++ b/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/file/ContentTypeDetectorTest.java
@@ -8,7 +8,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 
-import javax.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MediaType;
 
 import org.junit.jupiter.api.Test;
 

--- a/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/messaging/JsonObjectsTest.java
+++ b/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/messaging/JsonObjectsTest.java
@@ -1,11 +1,11 @@
 package uk.gov.justice.fileservice.common.messaging;
 
-import static javax.json.Json.createObjectBuilder;
+import static jakarta.json.Json.createObjectBuilder;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
 
 import org.junit.jupiter.api.Test;
 

--- a/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/util/UtcClock.java
+++ b/file-service-utils/src/test/java/uk/gov/justice/fileservice/common/util/UtcClock.java
@@ -5,7 +5,7 @@ import static java.time.temporal.ChronoUnit.MILLIS;
 
 import java.time.ZonedDateTime;
 
-import javax.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.context.ApplicationScoped;
 
 /**
  * Implementation of a clock that always generates a {@link ZonedDateTime} in UTC.

--- a/file-service/file-service-api/pom.xml
+++ b/file-service/file-service-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>file-service</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -13,8 +13,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/file-service/file-service-api/src/main/java/uk/gov/justice/services/fileservice/api/FileRetriever.java
+++ b/file-service/file-service-api/src/main/java/uk/gov/justice/services/fileservice/api/FileRetriever.java
@@ -6,7 +6,7 @@ import uk.gov.justice.services.fileservice.domain.FileReference;
 import java.util.Optional;
 import java.util.UUID;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 /**
  * Entry point for retrieving files from the File Server. Inject This class into you code to use.

--- a/file-service/file-service-api/src/main/java/uk/gov/justice/services/fileservice/api/FileStorer.java
+++ b/file-service/file-service-api/src/main/java/uk/gov/justice/services/fileservice/api/FileStorer.java
@@ -4,7 +4,7 @@ package uk.gov.justice.services.fileservice.api;
 import java.io.InputStream;
 import java.util.UUID;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 /**
  * Entry point for Storing files on the File Server. Inject This class into you code to use.

--- a/file-service/file-service-api/src/main/java/uk/gov/justice/services/fileservice/domain/FileReference.java
+++ b/file-service/file-service-api/src/main/java/uk/gov/justice/services/fileservice/domain/FileReference.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 /**
  * Reference to a file stored on the file server. Contains the file's id, the file's metadata as

--- a/file-service/file-service-api/src/main/resources/META-INF/beans.xml
+++ b/file-service/file-service-api/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
 </beans>

--- a/file-service/file-service-api/src/test/java/uk/gov/justice/services/fileservice/domain/FileReferenceTest.java
+++ b/file-service/file-service-api/src/test/java/uk/gov/justice/services/fileservice/domain/FileReferenceTest.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.UUID;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.Test;
 

--- a/file-service/file-service-it/pom.xml
+++ b/file-service/file-service-it/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>file-service</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -13,8 +13,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -48,7 +48,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/file-service/file-service-it/src/test/java/uk/gov/justice/services/fileservice/it/FileServiceIT.java
+++ b/file-service/file-service-it/src/test/java/uk/gov/justice/services/fileservice/it/FileServiceIT.java
@@ -3,7 +3,7 @@ package uk.gov.justice.services.fileservice.it;
 import static java.io.File.createTempFile;
 import static java.nio.file.Files.copy;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static javax.json.Json.createObjectBuilder;
+import static jakarta.json.Json.createObjectBuilder;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -31,8 +31,8 @@ import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.UUID;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 import javax.sql.DataSource;
 
 import org.apache.commons.logging.LogFactory;

--- a/file-service/file-service-it/src/test/java/uk/gov/justice/services/fileservice/repository/MetadataJdbcRepositoryIT.java
+++ b/file-service/file-service-it/src/test/java/uk/gov/justice/services/fileservice/repository/MetadataJdbcRepositoryIT.java
@@ -1,7 +1,7 @@
 package uk.gov.justice.services.fileservice.repository;
 
 import static java.util.UUID.randomUUID;
-import static javax.json.Json.createReader;
+import static jakarta.json.Json.createReader;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -15,7 +15,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.UUID;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;

--- a/file-service/file-service-liquibase/pom.xml
+++ b/file-service/file-service-liquibase/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>file-service</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/file-service/file-service-persistence/pom.xml
+++ b/file-service/file-service-persistence/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>file-service</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -18,8 +18,8 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax</groupId>
-            <artifactId>javaee-api</artifactId>
+            <groupId>jakarta.platform</groupId>
+            <artifactId>jakarta.jakartaee-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/client/FileService.java
+++ b/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/client/FileService.java
@@ -13,8 +13,8 @@ import java.io.InputStream;
 import java.util.Optional;
 import java.util.UUID;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
 
 import org.slf4j.Logger;
 

--- a/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/ContentJdbcRepository.java
+++ b/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/ContentJdbcRepository.java
@@ -19,7 +19,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Class for handling inserts/updates/selects on the 'content' database table. This class is not

--- a/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/DataSourceProvider.java
+++ b/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/DataSourceProvider.java
@@ -6,8 +6,8 @@ import uk.gov.justice.fileservice.common.jdbc.persistence.InitialContextFactory;
 import uk.gov.justice.services.fileservice.api.ConfigurationException;
 import uk.gov.justice.services.fileservice.api.FileServiceException;
 
-import javax.enterprise.inject.Default;
-import javax.inject.Inject;
+import jakarta.enterprise.inject.Default;
+import jakarta.inject.Inject;
 import javax.naming.NamingException;
 import javax.sql.DataSource;
 

--- a/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/FileStore.java
+++ b/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/FileStore.java
@@ -19,9 +19,9 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
-import javax.transaction.Transactional;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
+import jakarta.transaction.Transactional;
 
 
 /**

--- a/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/MetadataJdbcRepository.java
+++ b/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/MetadataJdbcRepository.java
@@ -1,11 +1,13 @@
 package uk.gov.justice.services.fileservice.repository;
 
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+import static uk.gov.justice.fileservice.common.messaging.JsonObjects.jsonReaderFactory;
+
 import uk.gov.justice.services.fileservice.api.DataIntegrityException;
 import uk.gov.justice.services.fileservice.api.FileServiceException;
 import uk.gov.justice.services.fileservice.api.StorageException;
 
-import javax.json.JsonObject;
-import javax.json.JsonReader;
 import java.io.StringReader;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -14,9 +16,8 @@ import java.sql.SQLException;
 import java.util.Optional;
 import java.util.UUID;
 
-import static java.util.Optional.empty;
-import static java.util.Optional.of;
-import static uk.gov.justice.fileservice.common.messaging.JsonObjects.jsonReaderFactory;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
 
 /**
  * Class for handling inserts/updates/selects on the 'metadata' database table. This class is not

--- a/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/MetadataUpdater.java
+++ b/file-service/file-service-persistence/src/main/java/uk/gov/justice/services/fileservice/repository/MetadataUpdater.java
@@ -10,10 +10,10 @@ import uk.gov.justice.services.fileservice.api.StorageException;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 
-import javax.inject.Inject;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
-import javax.ws.rs.core.MediaType;
+import jakarta.inject.Inject;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.ws.rs.core.MediaType;
 
 /**
  * Adds default required fields to the metadata json. Currently these fields are:

--- a/file-service/file-service-persistence/src/main/resources/META-INF/beans.xml
+++ b/file-service/file-service-persistence/src/main/resources/META-INF/beans.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+<beans xmlns="https://jakarta.ee/xml/ns/jakartaee"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       version="1.1" bean-discovery-mode="all">
+       xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/beans_4_0.xsd"
+       version="4.0" bean-discovery-mode="all">
 </beans>

--- a/file-service/file-service-persistence/src/test/java/uk/gov/justice/services/fileservice/client/FileServiceTest.java
+++ b/file-service/file-service-persistence/src/test/java/uk/gov/justice/services/fileservice/client/FileServiceTest.java
@@ -18,7 +18,7 @@ import java.io.InputStream;
 import java.util.Optional;
 import java.util.UUID;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;

--- a/file-service/file-service-persistence/src/test/java/uk/gov/justice/services/fileservice/repository/FileStoreTest.java
+++ b/file-service/file-service-persistence/src/test/java/uk/gov/justice/services/fileservice/repository/FileStoreTest.java
@@ -30,7 +30,7 @@ import java.time.ZonedDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 import javax.sql.DataSource;
 
 import org.junit.jupiter.api.Test;

--- a/file-service/file-service-persistence/src/test/java/uk/gov/justice/services/fileservice/repository/MetadataUpdaterTest.java
+++ b/file-service/file-service-persistence/src/test/java/uk/gov/justice/services/fileservice/repository/MetadataUpdaterTest.java
@@ -3,7 +3,7 @@ package uk.gov.justice.services.fileservice.repository;
 import static com.jayway.jsonassert.JsonAssert.with;
 import static java.time.ZoneOffset.UTC;
 import static java.time.ZonedDateTime.of;
-import static javax.json.Json.createObjectBuilder;
+import static jakarta.json.Json.createObjectBuilder;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -19,8 +19,8 @@ import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.time.ZonedDateTime;
 
-import javax.json.JsonObject;
-import javax.ws.rs.core.MediaType;
+import jakarta.json.JsonObject;
+import jakarta.ws.rs.core.MediaType;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/file-service/file-service-test-utils/pom.xml
+++ b/file-service/file-service-test-utils/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>file-service</artifactId>
         <groupId>uk.gov.justice.services</groupId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
+            <artifactId>jakarta.json</artifactId>
             <scope>provided</scope>
         </dependency>
 

--- a/file-service/file-service-test-utils/src/main/java/uk/gov/justice/services/fileservice/utils/test/FileServiceTestClient.java
+++ b/file-service/file-service-test-utils/src/main/java/uk/gov/justice/services/fileservice/utils/test/FileServiceTestClient.java
@@ -18,7 +18,7 @@ import java.sql.Connection;
 import java.util.Optional;
 import java.util.UUID;
 
-import javax.json.JsonObject;
+import jakarta.json.JsonObject;
 
 /**
  * Test client for testing input/output to the File Service

--- a/file-service/pom.xml
+++ b/file-service/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.justice.framework</groupId>
         <artifactId>cp-file-service</artifactId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>uk.gov.justice</groupId>
         <artifactId>maven-framework-parent-pom</artifactId>
-        <version>17.103.0</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>uk.gov.justice.framework</groupId>
     <artifactId>cp-file-service</artifactId>
-    <version>17.104.0-M4-SNAPSHOT</version>
+    <version>21.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Framework File service</name>
@@ -28,20 +28,9 @@
 
     <properties>
         <cpp.repo.name>cp-file-service</cpp.repo.name>
-        <maven-common-bom.version>17.104.0-M1</maven-common-bom.version>
+        <maven-common-bom.version>21.0.0-SNAPSHOT</maven-common-bom.version>
 
         <!-- plugin related -->
-        <plugins.maven.compiler.version>3.10.1</plugins.maven.compiler.version>
-        <java.major.version>17</java.major.version>
-        <compiler.debug>true</compiler.debug>
-        <compiler.debuglevel>lines,vars,source</compiler.debuglevel>
-        <compiler.showdeprecation>true</compiler.showdeprecation>
-        <compiler.showwarnings>true</compiler.showwarnings>
-        <compiler.optimise>true</compiler.optimise>
-        <compiler.max.errors>100</compiler.max.errors>
-        <compiler.max.warnings>100</compiler.max.warnings>
-        <jaxb.version>2.3.1</jaxb.version>
-        <plugins.coveralls.version>4.3.0</plugins.coveralls.version>
         <plugins.maven.failsafe.version>3.1.2</plugins.maven.failsafe.version>
     </properties>
 
@@ -88,6 +77,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-failsafe-plugin</artifactId>
                         <version>${plugins.maven.failsafe.version}</version>
+                        <configuration>
+                            <argLine>@{argLine} -Dnet.bytebuddy.experimental=true --add-opens java.base/java.lang=ALL-UNNAMED</argLine>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>integration-test</id>

--- a/test-utils/pom.xml
+++ b/test-utils/pom.xml
@@ -6,12 +6,12 @@
     <parent>
         <groupId>uk.gov.justice.framework</groupId>
         <artifactId>cp-file-service</artifactId>
-        <version>17.104.0-M4-SNAPSHOT</version>
+        <version>21.0.0-SNAPSHOT</version>
     </parent>
 
     <groupId>uk.gov.justice.file.service</groupId>
     <artifactId>test-utils</artifactId>
-    <version>17.104.0-M4-SNAPSHOT</version>
+    <version>21.0.0-SNAPSHOT</version>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Summary
- Updated to `maven-framework-parent-pom` and `maven-common-bom` `21.0.0-SNAPSHOT`
- Migrated `beans.xml` descriptors from version `1.1` to `4.0` across all modules
- Replaced `org.glassfish:javax.json` with `org.glassfish:jakarta.json`
- Migrated all source files to `jakarta.*` imports

## Test plan
- [ ] `mvn clean install -Denforcer.skip=true` passes
🤖 Generated with [Claude Code](https://claude.com/claude-code)