### PR TITLE
Remove liquibase.hub.mode property removed in Liquibase 4.12.0

### DIFF
--- a/file-service/file-service-liquibase/src/main/resources/liquibase.properties
+++ b/file-service/file-service-liquibase/src/main/resources/liquibase.properties
@@ -1,5 +1,4 @@
 changelog-file: liquibase/file-service-liquibase-db-changelog.xml
-liquibase.hub.mode: off
 liquibase.headless: true
 
 # Stop liquibase collecting anonymous analytics should we ever upgrade to liquibase 4.30.0 or greater


### PR DESCRIPTION
## Summary

- `liquibase.hub.mode` was removed in Liquibase 4.12.0
- Any Liquibase JAR bundling 4.12.0+ rejects it under strict checking and exits non-zero
- This causes the Kubernetes pre-install Liquibase job to time out at 900s
- Affects: `file-service-liquibase`

## Fix

Remove `liquibase.hub.mode: off` from `file-service-liquibase/src/main/resources/liquibase.properties`.

## Test plan

- [ ] Build passes: `mvn clean install`
- [ ] Pipeline re-run confirms Liquibase steps succeed